### PR TITLE
change Ruby version to match Heroku requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.0.0"
+ruby "~> 3.0.0"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4"


### PR DESCRIPTION
Heroku runtimes require at least Ruby 3.1.0
<img width="789" alt="Screen Shot 2022-09-29 at 8 48 54 AM" src="https://user-images.githubusercontent.com/23530380/193049911-3175996a-0174-4401-a27e-6043bbe4ece5.png">
